### PR TITLE
Fix build for recent Cabal

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -3,4 +3,4 @@ module Main (main) where
 import Distribution.Simple
 
 main :: IO ()
-main = defaultMainWithHooks defaultUserHooks
+main = defaultMainWithHooks autoconfUserHooks


### PR DESCRIPTION
It currently fails with:

```
/home/kb/workspace/statvfs/Setup.hs:6:29: error:                                                                                    
    Variable not in scope: defaultUserHooks :: UserHooks                                                                            
  |                                                                                                                                 
6 | main = defaultMainWithHooks defaultUserHooks                                                                                    
  |                             ^^^^^^^^^^^^^^^^                                                                                    
```
